### PR TITLE
Insert input containers in batches

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 import { app, errorHandler } from "mu";
 import bodyParser from "body-parser";
 import { Delta } from "./lib/delta";
-import { STATUS_SUCCESS, STATUS_FAILED, STATUS_SCHEDULED } from "./constants";
+import { STATUS_SUCCESS, STATUS_FAILED, STATUS_PREPARING } from "./constants";
 import { loadTask, createTask, isTask, taskExists } from "./lib/task";
 import { loadJob, updateJob } from "./lib/job";
 import  * as jobsConfig  from "./config/config.json";
@@ -95,7 +95,7 @@ async function scheduleNextTask(currentTaskUri) {
       job.job,
       currentTaskConfig.nextIndex,
       currentTaskConfig.nextOperation,
-      STATUS_SCHEDULED,
+      STATUS_PREPARING,
       [task.task],
       task.resultsContainers,
     );

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 import { app, errorHandler } from "mu";
 import bodyParser from "body-parser";
 import { Delta } from "./lib/delta";
-import { STATUS_SUCCESS, STATUS_FAILED, STATUS_PREPARING } from "./constants";
+import { STATUS_SUCCESS, STATUS_FAILED, STATUS_SCHEDULED } from "./constants";
 import { loadTask, createTask, isTask, taskExists } from "./lib/task";
 import { loadJob, updateJob } from "./lib/job";
 import  * as jobsConfig  from "./config/config.json";

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 import { app, errorHandler } from "mu";
 import bodyParser from "body-parser";
 import { Delta } from "./lib/delta";
-import { STATUS_SUCCESS, STATUS_FAILED, STATUS_SCHEDULED } from "./constants";
+import { STATUS_SUCCESS, STATUS_FAILED, STATUS_PREPARING } from "./constants";
 import { loadTask, createTask, isTask, taskExists } from "./lib/task";
 import { loadJob, updateJob } from "./lib/job";
 import  * as jobsConfig  from "./config/config.json";

--- a/constants.js
+++ b/constants.js
@@ -2,6 +2,7 @@ import envvar from 'env-var';
 import * as N3 from 'n3';
 const { namedNode } = N3.DataFactory;
 
+export const STATUS_PREPARING = 'http://redpencil.data.gift/id/concept/JobStatus/preparing';
 export const STATUS_BUSY = 'http://redpencil.data.gift/id/concept/JobStatus/busy';
 export const STATUS_SCHEDULED = 'http://redpencil.data.gift/id/concept/JobStatus/scheduled';
 export const STATUS_SUCCESS = 'http://redpencil.data.gift/id/concept/JobStatus/success';

--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,7 @@
+import envvar from 'env-var';
+import * as N3 from 'n3';
+const { namedNode } = N3.DataFactory;
+
 export const STATUS_BUSY = 'http://redpencil.data.gift/id/concept/JobStatus/busy';
 export const STATUS_SCHEDULED = 'http://redpencil.data.gift/id/concept/JobStatus/scheduled';
 export const STATUS_SUCCESS = 'http://redpencil.data.gift/id/concept/JobStatus/success';
@@ -7,17 +11,120 @@ export const JOB_TYPE = 'http://vocab.deri.ie/cogs#Job';
 export const TASK_TYPE = 'http://redpencil.data.gift/vocabularies/tasks/Task';
 export const ERROR_TYPE= 'http://open-services.net/ns/core#Error';
 
-export const PREFIXES = `
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
-  PREFIX dct: <http://purl.org/dc/terms/>
-  PREFIX prov: <http://www.w3.org/ns/prov#>
-  PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX oslc: <http://open-services.net/ns/core#>
-  PREFIX cogs: <http://vocab.deri.ie/cogs#>
-  PREFIX adms: <http://www.w3.org/ns/adms#>
-`;
+/**
+ * Prefixes used in SPARQL queries (mostly).
+ *
+ * @private
+ * @constant
+ */
+const PREFIXES = {
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+  owl: 'http://www.w3.org/2002/07/owl#',
+  mu: 'http://mu.semte.ch/vocabularies/core/',
+  task: 'http://redpencil.data.gift/vocabularies/tasks/',
+  prov: 'http://www.w3.org/ns/prov#',
+  oslc: 'http://open-services.net/ns/core#',
+  dct: 'http://purl.org/dc/terms/',
+  adms: 'http://www.w3.org/ns/adms#',
+  nie: 'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#',
+  ext: 'http://mu.semte.ch/vocabularies/ext/',
+  cogs: 'http://vocab.deri.ie/cogs#',
+  nfo: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+  dbpedia: 'http://dbpedia.org/ontology/',
+  jobstat: 'http://redpencil.data.gift/id/concept/JobStatus/',
+  tasko: 'http://lblod.data.gift/id/jobs/concept/TaskOperation/',
+  app: 'http://lblod.data.gift/id/app/',
+};
+
+/**
+ * Some extra prefixes mostly used for writing the data to TTL files in the
+ * cleanest possible way.
+ *
+ * @private
+ * @constant
+ */
+const EXTRA_PREFIXES = {
+  lblod: 'http://data.lblod.info/id/',
+  ere: 'http://data.lblod.info/vocabularies/erediensten/',
+  mandaat: 'http://data.vlaanderen.be/ns/mandaat#',
+  org: 'http://www.w3.org/ns/org#',
+  mandaten: 'http://data.lblod.info/id/mandaten/',
+  schema: 'http://schema.org/',
+  person: 'http://www.w3.org/ns/person#',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  persoon: 'https://data.vlaanderen.be/ns/persoon#',
+  skos: 'http://www.w3.org/2004/02/skos/core#',
+  locn: 'http://www.w3.org/ns/locn#',
+  contacthub: 'http://data.lblod.info/vocabularies/contacthub/',
+  adres: 'https://data.vlaanderen.be/ns/adres#',
+  positiesBedienaar: 'http://data.lblod.info/id/positiesBedienaar/',
+  vlaanderen: 'https://data.vlaanderen.be/id/',
+  country: 'http://publications.europa.eu/resource/authority/country/',
+  gender: 'http://publications.europa.eu/resource/authority/human-sex/',
+};
+
+/**
+ * This string contains all the prefixes, ready for use in a SPARQL query.
+ *
+ * @public
+ * @constant
+ * @type {String}
+ */
+export const SPARQL_PREFIXES = (() => {
+  const all = [];
+  for (const key in PREFIXES) all.push(`PREFIX ${key}: <${PREFIXES[key]}>`);
+  return all.join('\n');
+})();
+
+/**
+ * This object contains all the prefixes a TTL writer might want to use to
+ * create prefixed output. It is in the same format as the PREFIXES and
+ * EXTRA_PREFIXES.
+ *
+ * @see PREFIXES, EXTRA_PREFIXES
+ * @public
+ * @constant
+ * @type {Object}
+ */
+export const WRITER_PREFIXES = (() => {
+  const prefs = {};
+  for (const key in PREFIXES) prefs[key] = PREFIXES[key];
+  for (const key in EXTRA_PREFIXES) prefs[key] = EXTRA_PREFIXES[key];
+  return prefs;
+})();
+
+/**
+ * This object is produced on application startup.
+ * It is an object with the same keys as the PREFIXES, but every value is now a
+ * template function to produce a namedNode with the given ID in the selected
+ * namespace.
+ * E.g. if you execute
+ *   NAMESPACES.rdf`type`
+ * you get the same as
+ *   namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+ *
+ * @public
+ * @constant
+ * @type {Object}
+ * @param {String} pred - Every value in this object is a fuction that takes an
+ * identifier to produce a full URI.
+ * @returns {NamedNode} Represents the created individual by its URI.
+ */
+export const NAMESPACES = (() => {
+  const all = {};
+  for (const key in PREFIXES)
+    all[key] = (pred) => namedNode(`${PREFIXES[key]}${pred}`);
+  return all;
+})();
 
 export const TASK_URI_PREFIX = 'http://redpencil.data.gift/id/task/';
 export const ERROR_URI_PREFIX = 'http://redpencil.data.gift/id/jobs/error/';
+
+export const SLEEP_TIME = envvar.get('SLEEP_TIME').default('1000').asInt();
+export const BATCH_SIZE = envvar.get('BATCH_SIZE').default('100').asInt();
+export const RETRY_WAIT_INTERVAL = envvar
+  .get('RETRY_WAIT_INTERVAL')
+  .default('30000')
+  .asInt();
+export const MAX_RETRIES = envvar.get('MAX_RETRIES').default('10').asInt();

--- a/constants.js
+++ b/constants.js
@@ -94,30 +94,6 @@ export const WRITER_PREFIXES = (() => {
   return prefs;
 })();
 
-/**
- * This object is produced on application startup.
- * It is an object with the same keys as the PREFIXES, but every value is now a
- * template function to produce a namedNode with the given ID in the selected
- * namespace.
- * E.g. if you execute
- *   NAMESPACES.rdf`type`
- * you get the same as
- *   namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
- *
- * @public
- * @constant
- * @type {Object}
- * @param {String} pred - Every value in this object is a fuction that takes an
- * identifier to produce a full URI.
- * @returns {NamedNode} Represents the created individual by its URI.
- */
-export const NAMESPACES = (() => {
-  const all = {};
-  for (const key in PREFIXES)
-    all[key] = (pred) => namedNode(`${PREFIXES[key]}${pred}`);
-  return all;
-})();
-
 export const TASK_URI_PREFIX = 'http://redpencil.data.gift/id/task/';
 export const ERROR_URI_PREFIX = 'http://redpencil.data.gift/id/jobs/error/';
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,11 +1,11 @@
 import { sparqlEscapeUri, uuid, sparqlEscapeString } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { PREFIXES, ERROR_URI_PREFIX, ERROR_TYPE } from '../constants';
+import { SPARQL_PREFIXES, ERROR_URI_PREFIX, ERROR_TYPE } from '../constants';
 import { parseResult } from './utils';
 
 export async function loadError( subject ){
   const queryError = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT DISTINCT ?graph ?error ?message WHERE {
      GRAPH ?graph {
        BIND(${ sparqlEscapeUri(subject) } as ?error)
@@ -21,7 +21,7 @@ export async function createError( graph, message ){
   const uri = ERROR_URI_PREFIX + id;
 
   const queryError = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    INSERT DATA {
     GRAPH ${sparqlEscapeUri(graph)}{
       ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(ERROR_TYPE)};

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,11 +1,11 @@
 import { sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { JOB_TYPE, PREFIXES } from '../constants';
+import { JOB_TYPE, SPARQL_PREFIXES } from '../constants';
 import { parseResult } from './utils';
 
 export async function loadJob( subject ){
   const queryJob = `
-    ${PREFIXES}
+    ${SPARQL_PREFIXES}
     SELECT DISTINCT ?graph ?job ?created ?modified ?creator ?status ?error ?operation WHERE {
      GRAPH ?graph {
        BIND(${sparqlEscapeUri(subject)} AS ?job)
@@ -26,7 +26,7 @@ export async function loadJob( subject ){
 
   //load has many
   const queryTasks = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT DISTINCT ?job ?task WHERE {
      GRAPH ?g {
        BIND(${ sparqlEscapeUri(subject) } as ?job)
@@ -54,7 +54,7 @@ export async function updateJob( job ){
         .join('\n');
 
   const updateQuery = `
-    ${PREFIXES}
+    ${SPARQL_PREFIXES}
     DELETE {
       GRAPH ?g {
         ?job dct:creator ?creator;

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { NAMESPACES as ns, TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED } from '../constants';
+import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED } from '../constants';
 import { parseResult, writeTriplesToGraph } from './utils';
 
 import * as N3 from 'n3';

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { NAMESPACES as ns, TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED } from '../constants';
+import { NAMESPACES as ns, TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED } from '../constants';
 import { parseResult, writeTriplesToGraph } from './utils';
 
 import * as N3 from 'n3';

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,12 +1,15 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { TASK_TYPE, PREFIXES, TASK_URI_PREFIX, STATUS_FAILED } from '../constants';
-import { parseResult } from './utils';
+import { NAMESPACES as ns, TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED } from '../constants';
+import { parseResult, writeTriplesToGraph } from './utils';
+
+import * as N3 from 'n3';
+const { namedNode } = N3.DataFactory;
 
 export async function isTask( subject ){
   //TODO: move to ask query
   const queryStr = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT ?subject WHERE {
     GRAPH ?g {
       BIND(${ sparqlEscapeUri(subject) } as ?subject)
@@ -20,7 +23,7 @@ export async function isTask( subject ){
 
 export async function loadTask( subject ){
   const queryTask = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT DISTINCT ?graph ?task ?job ?created ?modified ?status ?index ?operation ?error WHERE {
     GRAPH ?graph {
       BIND(${ sparqlEscapeUri(subject) } as ?task)
@@ -42,7 +45,7 @@ export async function loadTask( subject ){
 
   //now fetch the hasMany. Easier to parse these
   const queryParentTasks = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT DISTINCT ?task ?parentTask WHERE {
      GRAPH ?g {
        BIND(${ sparqlEscapeUri(subject) } as ?task)
@@ -56,7 +59,7 @@ export async function loadTask( subject ){
   task.parentSteps = parentTasks;
 
   const queryResultsContainers = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT DISTINCT ?task ?resultsContainer WHERE {
      GRAPH ?g {
        BIND(${ sparqlEscapeUri(subject) } as ?task)
@@ -69,7 +72,7 @@ export async function loadTask( subject ){
   task.resultsContainers = resultsContainers;
 
   const queryInputContainers = `
-   ${PREFIXES}
+   ${SPARQL_PREFIXES}
    SELECT DISTINCT ?task ?inputContainer WHERE {
      GRAPH ?g {
        BIND(${ sparqlEscapeUri(subject) } as ?task)
@@ -85,7 +88,7 @@ export async function loadTask( subject ){
 
 export async function loadTasksForJob( jobUri ){
   const queryTasks = `
-    ${PREFIXES}
+    ${SPARQL_PREFIXES}
     SELECT DISTINCT ?job ?task WHERE {
       GRAPH ?g {
         BIND(${jobUri} as ?job)
@@ -107,7 +110,7 @@ export async function loadTasksForJob( jobUri ){
 
 export async function taskExists(graph, job, index, operation) {
     const queryStr = `
-        ${PREFIXES}
+        ${SPARQL_PREFIXES}
         SELECT ?task {
             GRAPH <${graph}> {
                 ?task a <${TASK_TYPE}>;
@@ -128,16 +131,24 @@ export async function createTask( graph, job, index, operation, status, parentTa
   const uri = TASK_URI_PREFIX + id;
   const created = new Date();
 
+  // First, we write the input containers in batches, because the number of input containers can be too much for one INSERT query
+  const inputContainersStore = new N3.Store();
+  inputContainers.map(container => 
+    inputContainersStore.addQuad(
+      namedNode(uri),
+      namedNode("http://redpencil.data.gift/vocabularies/tasks/inputContainer"),
+      namedNode(container),
+      namedNode(graph)
+    )
+  );
+  await writeTriplesToGraph(namedNode(graph), inputContainersStore);
+
   const parentTaskTriples = parentTasks
         .map(parent => `${sparqlEscapeUri(uri)} cogs:dependsOn ${sparqlEscapeUri(parent)}.`)
         .join('\n');
 
-  const inputContainerTriples = inputContainers
-        .map(container => `${sparqlEscapeUri(uri)} task:inputContainer ${sparqlEscapeUri(container)}.`)
-        .join('\n');
-
-  const insertQuery = `
-    ${PREFIXES}
+   const insertQuery = `
+    ${SPARQL_PREFIXES}
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(graph)} {
        ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(TASK_TYPE)};
@@ -150,7 +161,6 @@ export async function createTask( graph, job, index, operation, status, parentTa
                 task:operation ${sparqlEscapeUri(operation)}.
 
         ${parentTaskTriples}
-        ${inputContainerTriples}
       }
     }
   `;
@@ -158,4 +168,39 @@ export async function createTask( graph, job, index, operation, status, parentTa
   await update(insertQuery);
 
   return await loadTask(uri);
+}
+
+/**
+ * Updates the task with a new status in the triplestore.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {string} task - Represents the URI of the task.
+ * @param {string} status - The new status.
+ * @returns {undefined} Nothing
+ */
+export async function updateTaskStatus(task, status) {
+  const now = new Date().toISOString();
+  return update(`
+    ${SPARQL_PREFIXES}
+    DELETE {
+      GRAPH ?g {
+        ?subject adms:status ?status .
+        ?subject dct:modified ?modified .
+      }
+    }
+    INSERT {
+      GRAPH ?g {
+       ?subject adms:status ${sparqlEscapeUri(status)} .
+       ?subject dct:modified ${sparqlEscapeDateTime(now)} .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        BIND(${sparqlEscapeUri(task)} as ?subject)
+        ?subject adms:status ?status .
+        OPTIONAL { ?subject dct:modified ?modified . }
+      }
+    }`);
 }

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED } from '../constants';
+import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED } from '../constants';
 import { parseResult, writeTriplesToGraph } from './utils';
 
 import * as N3 from 'n3';
@@ -131,18 +131,7 @@ export async function createTask( graph, job, index, operation, status, parentTa
   const uri = TASK_URI_PREFIX + id;
   const created = new Date();
 
-  // First, we write the input containers in batches, because the number of input containers can be too much for one INSERT query
-  const inputContainersStore = new N3.Store();
-  inputContainers.map(container => 
-    inputContainersStore.addQuad(
-      namedNode(uri),
-      namedNode("http://redpencil.data.gift/vocabularies/tasks/inputContainer"),
-      namedNode(container),
-      namedNode(graph)
-    )
-  );
-  await writeTriplesToGraph(namedNode(graph), inputContainersStore);
-
+  // First, the task will be created with "preparing" status
   const parentTaskTriples = parentTasks
         .map(parent => `${sparqlEscapeUri(uri)} cogs:dependsOn ${sparqlEscapeUri(parent)}.`)
         .join('\n');
@@ -167,6 +156,21 @@ export async function createTask( graph, job, index, operation, status, parentTa
 
   await update(insertQuery);
 
+  // Second, we write the input containers in batches, because the number of input containers can be too much for one INSERT query
+  const inputContainersStore = new N3.Store();
+  inputContainers.map(container => 
+    inputContainersStore.addQuad(
+      namedNode(uri),
+      namedNode("http://redpencil.data.gift/vocabularies/tasks/inputContainer"),
+      namedNode(container),
+      namedNode(graph)
+    )
+  );
+  await writeTriplesToGraph(namedNode(graph), inputContainersStore);
+
+  // Third, we update the task to "scheduled"
+  await updateTaskStatus(uri, STATUS_SCHEDULED);
+  
   return await loadTask(uri);
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,26 +80,6 @@ async function storeToString(store, forSparql = true) {
 }
 
 /**
- * Gets the triples related to a task. It first tries to get the triples from
- * the file related to the inputContainer, but if that fails, it tries to get
- * the files from the graph related to the inputContainer.
- *
- * @public
- * @async
- * @function
- * @param {NamedNode} task -
- * @returns {N3.Store}
- */
-export async function getTriples(task) {
-  try {
-    return getTriplesInFile(task);
-  } catch (e) {
-    console.error('An error occurred, trying from graph', e);
-    return getTriplesInGraph(task);
-  }
-}
-
-/**
  * Writes a store with triples to the triplestore in the specified graph. The
  * triples are split in smaller queries according to a batch size. If an insert
  * fails, the batch size is reduced and tried again.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,11 @@
+
+import { WRITER_PREFIXES, BATCH_SIZE, SLEEP_TIME } from '../constants';
+import { updateSudo } from '@lblod/mu-auth-sudo';
+import { termToString } from 'rdf-string-ttl';
+
+import * as N3 from 'n3';
+
+
 /**
  * convert results of select query to an array of objects.
  * courtesy: Niels Vandekeybus & Felix
@@ -22,3 +30,142 @@ export function parseResult( result ) {
     return obj;
   });
 };
+
+/**
+ * Convert a store of quads into a string that can be inserted in a SPARQL
+ * query.
+ *
+ * @public
+ * @function
+ * @param {N3.Store|Iterable} store - A collection (N3.Store or Array, or
+ * something else that can iterated on) that contains RDF.js quads.
+ * @returns {String} The triples in SPARQL body form. (No graphs and no
+ * prefixes.)
+ */
+export async function storeToSparql(store) {
+  return await storeToString(store, true);
+}
+
+/**
+ * Converts a store of quads into a string, with or without prefixes.
+ *
+ * @function
+ * @param {N3.Store|Iterable} store - A collection (N3.Store or Array, or
+ * something else that can iterated on) that contains RDF.js quads.
+ * @param {Boolean} [forSparql = true] - If true, the result will be formatted
+ * in N-Triples syntax (without prefixes) so it can be used inside a SPARQL
+ * query. If false, the result will contain prefix definitions at the top of
+ * the file that will be used throughout the file and will be formatted in
+ * more dense Turtle syntax.
+ *
+ * **NOTE:** realistically, the difference between N-Triples and Turtle syntax
+ * is not big. Some datatypes are less explicit in Turtle, such as booleans,
+ * which causes mu-authorization to fail.
+ */
+async function storeToString(store, forSparql = true) {
+  // Use the WRITER_PREFIXES, there is much more in them than what is needed
+  // for the SPARQL queries.
+  const options = forSparql
+    ? { format: 'N-Triples' }
+    : { format: 'Turtle', prefixes: WRITER_PREFIXES };
+  const writer = new N3.Writer(options);
+  store.forEach((q) => writer.addQuad(q.subject, q.predicate, q.object));
+
+  return new Promise((resolve, reject) => {
+    writer.end((err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
+
+/**
+ * Gets the triples related to a task. It first tries to get the triples from
+ * the file related to the inputContainer, but if that fails, it tries to get
+ * the files from the graph related to the inputContainer.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {NamedNode} task -
+ * @returns {N3.Store}
+ */
+export async function getTriples(task) {
+  try {
+    return getTriplesInFile(task);
+  } catch (e) {
+    console.error('An error occurred, trying from graph', e);
+    return getTriplesInGraph(task);
+  }
+}
+
+/**
+ * Writes a store with triples to the triplestore in the specified graph. The
+ * triples are split in smaller queries according to a batch size. If an insert
+ * fails, the batch size is reduced and tried again.
+ *
+ * TODO: maybe a rewrite without recursion? Recursion has limits in JavaScript,
+ * but even large numbers of triples won't create too much recursion (log₂(N))
+ * so it's not a big problem here.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {NamedNode} graph - Graph in which to insert the data.
+ * @param {N3.Store|Iterable} store - An N3.Store or other Iterable (like an
+ * Array) that contains RDF.js quads.
+ * @param {Integer} [batchSize] - This is used to split the collection of
+ * triples in a series of queries.
+ * @returns {undefined} Nothing.
+ */
+export async function writeTriplesToGraph(
+  graph,
+  store,
+  batchSize = BATCH_SIZE,
+) {
+  const triples = [...store];
+  const pages = Math.ceil(triples.length / batchSize);
+  for (let page = 0; page < pages; page++) {
+    const batch = triples.slice(page * batchSize, (page + 1) * batchSize);
+    const triplesString = await storeToSparql(batch);
+    const queryStr = `
+      INSERT DATA {
+        GRAPH ${termToString(graph)} {
+          ${triplesString}
+        }
+      }`;
+    try {
+      await updateSudo(queryStr);
+    } catch (e) {
+      if (batchSize > 1) {
+        console.warn(
+          `INSERT batch of triples failed. Retrying with smaller batch size ${Math.ceil(
+            batchSize / 2,
+          )}`,
+        );
+        await sleep(SLEEP_TIME);
+        await writeTriplesToGraph(graph, batch, Math.ceil(batchSize / 2));
+      } else {
+        console.error('INSERT of a triple failed:');
+        console.error(queryStr);
+        // Throw an error on any failed insertion after retrying as much as
+        // needed.
+        throw e;
+      }
+    }
+  }
+}
+
+/**
+ * Simple. Sleep for the given amount of milliseconds.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {Integer} ms - The amount of milliseconds to sleep for.
+ * @returns {undefined} Nothing. (Note that this is an async function, so you
+ * should `await` it or use the returned promise to wait for its resolution.)
+ */
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,22 @@
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^1.0.0-beta.4",
-        "body-parser": "~1.20.1"
-      },
-      "devDependencies": {}
+        "body-parser": "~1.20.1",
+        "n3": "^2.0.3",
+        "rdf-string-ttl": "^2.0.1",
+        "sparqljson-parse": "^3.3.0"
+      }
+    },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.2.tgz",
+      "integrity": "sha512-qUt0QNJjvg4s1zk+AuLM6s/zcsQ8MvGn7+1f0vPuxvpCYa08YtTryuDInngbEyW5fNGGYe2znKt61RMGd5HnXg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
     },
     "node_modules/@lblod/mu-auth-sudo": {
       "version": "1.0.0-beta.4",
@@ -26,6 +39,14 @@
       },
       "peerDependencies": {
         "express-http-context": "~1.2.4"
+      }
+    },
+    "node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -104,7 +125,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
       "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -122,6 +142,14 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -146,6 +174,17 @@
         "@types/send": "*"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/async-hook-jl": {
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
@@ -163,6 +202,25 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -186,6 +244,29 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes": {
@@ -375,6 +456,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/express-http-context": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/express-http-context/-/express-http-context-1.2.5.tgz",
@@ -503,6 +600,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -571,6 +687,18 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/n3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.0.3.tgz",
+      "integrity": "sha512-um/toGVENTarHBYIK2TdH6ByBhW75WpdKpv8iTYt9wF2QfBk8s8a16iaWZFUAAC1BKfGdb99kfgx6pltdDwfKA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -615,6 +743,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -644,6 +780,64 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-string-ttl": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-2.0.1.tgz",
+      "integrity": "sha512-xIZdC6uur9OwaCQrOsjuzLpnQCNGuJFWnYIAdF48tg3wzG5QzsgDMTJISCVh+M2p1e9ivIXlEauSdWokAhpZgA==",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -746,6 +940,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sparqljson-parse": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-3.3.0.tgz",
+      "integrity": "sha512-XrmkCsrx4n69Ak63Ju7t91hVlWw7YhEPPdA+giW2GRTosQxPur0JWh7rQin/8aT0WjKZgBgGpsNnVBYyyWUq1w==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.1",
+        "@types/readable-stream": "^4.0.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
     "node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
@@ -760,6 +969,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/toidentifier": {
@@ -794,8 +1011,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "license": "MIT",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^1.0.0-beta.4",
-    "body-parser": "~1.20.1"
+    "body-parser": "~1.20.1",
+    "n3": "^2.0.3",
+    "rdf-string-ttl": "^2.0.1"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PR adds following:

* updated the PREFIXES logic in constants.js, aligned with https://github.com/lblod/import-with-sameas-service . This allows splitting prefixes in SPARQL_PREFIXES (for SPARQL queries) and WRITER_PREFIXES (for N3 Writer).
*  Add utility functions for writing triples to graph in batches (writeTriplesToGraph, storeToString, storeToSparql), aligned with https://github.com/lblod/import-with-sameas-service . 
* Adapted createNewTask by first inserting the input containers in batches, then creating the new task.

After discussion with @nvdk 20/03/2026: we'll introduce a new state "preparing" and first create the task, then the input containers. This new state needs to be added in the dashboard https://github.com/lblod/frontend-harvesting-self-service/pull/48 

Clean up of tasks in "preparing" state can be done using this service: https://github.com/lblod/db-cleanup-service
A nice addition of this PR would be to document example configuration of cleanin up