### PR TITLE
fix: job loses links to tasks

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -45,8 +45,6 @@ export async function updateJob( job ){
   //TODO: review the error flow
   // Probably we want to attach the error to the task
   // and it somehow 'bubbles up' to the job
-  const storedJobData = await loadJob(job.job);
-
   job.modified = new Date();
 
   const tasksTriples = job.tasks

--- a/lib/job.js
+++ b/lib/job.js
@@ -62,8 +62,6 @@ export async function updateJob( job ){
            dct:created ?created;
            task:operation ?operation;
            dct:modified ?modified.
-
-        ?task dct:isPartOf ?job.
       }
     }
     WHERE {
@@ -75,8 +73,6 @@ export async function updateJob( job ){
          dct:created ?created;
          task:operation ?operation;
          dct:modified ?modified.
-
-       OPTIONAL { ?task dct:isPartOf ?job. }
       }
     }
 


### PR DESCRIPTION
This fixes the fact that the job sometimes loses links to tasks:

In update job, first loadJob is called, which fetches the information about the job, including its links to tasks.
Then, the original query DELETED the links to all tasks for the job and inserted the links it queried earlier.
Best case, this did nothing, worst case, it DELETES links that appeared between the moment the job information was fetched and the delete query executes.

Since it did nothing in the best case, I'm removing the delete of the task links here.