### PR TITLE
fix job completeness checking

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,14 +2,8 @@ import { app, errorHandler } from "mu";
 import bodyParser from "body-parser";
 import { Delta } from "./lib/delta";
 import { STATUS_SUCCESS, STATUS_FAILED, STATUS_PREPARING } from "./constants";
-import {
-  loadTask,
-  createTask,
-  isTask,
-  taskExists,
-  hasOnlySuccessfulTasks,
-} from "./lib/task";
-import { loadJob, updateJob } from "./lib/job";
+import { loadTask, createTask, isTask, taskExists } from "./lib/task";
+import { isJobComplete, loadJob, updateJob } from "./lib/job";
 import * as jobsConfig from "./config/config.json";
 
 app.get("/", function (_, res) {
@@ -65,7 +59,7 @@ app.post(
       console.error(`Delta processing failed:`, e.message);
       return next(e);
     }
-  }
+  },
 );
 
 async function scheduleNextTask(currentTaskUri) {
@@ -90,7 +84,7 @@ async function scheduleNextTask(currentTaskUri) {
   if (!currentTaskConfig) {
     //No config found for this task or final task in the job
     const previousTaskConfig = getPreviousTaskConfig(jobsConfig, job, task);
-    if (previousTaskConfig && (await hasOnlySuccessfulTasks(task.job))) {
+    if (previousTaskConfig && (await isJobComplete(job))) {
       //Task operation found as next operation is this config, so this is final task in job
       job.status = STATUS_SUCCESS;
       await updateJob(job);

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,9 +1,15 @@
-import { sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
-import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { JOB_TYPE, SPARQL_PREFIXES } from '../constants';
-import { parseResult } from './utils';
+import { sparqlEscapeUri, sparqlEscapeDateTime } from "mu";
+import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
+import {
+  JOB_TYPE,
+  SPARQL_PREFIXES,
+  STATUS_FAILED,
+  STATUS_SUCCESS,
+} from "../constants";
+import { parseResult } from "./utils";
+import * as jobsConfig from "../config/config.json";
 
-export async function loadJob( subject ){
+export async function loadJob(subject) {
   const queryJob = `
     ${SPARQL_PREFIXES}
     SELECT DISTINCT ?graph ?job ?created ?modified ?creator ?status ?error ?operation WHERE {
@@ -22,34 +28,39 @@ export async function loadJob( subject ){
   `;
 
   const job = parseResult(await query(queryJob))[0];
-  if(!job) return null;
+  if (!job) {
+    return null;
+  }
 
   //load has many
   const queryTasks = `
    ${SPARQL_PREFIXES}
    SELECT DISTINCT ?job ?task WHERE {
      GRAPH ?g {
-       BIND(${ sparqlEscapeUri(subject) } as ?job)
+       BIND(${sparqlEscapeUri(subject)} as ?job)
        ?task dct:isPartOf ?job
       }
     }
   `;
 
-  const tasks = parseResult(await query(queryTasks)).map(row => row.task);
+  const tasks = parseResult(await query(queryTasks)).map((row) => row.task);
   job.tasks = tasks;
 
   return job;
 }
 
-export async function updateJob( job ){
+export async function updateJob(job) {
   //TODO: review the error flow
   // Probably we want to attach the error to the task
   // and it somehow 'bubbles up' to the job
   job.modified = new Date();
 
   const tasksTriples = job.tasks
-        .map(task => `${sparqlEscapeUri(task)} dct:isPartOf ${sparqlEscapeUri(job.job)}.`)
-        .join('\n');
+    .map(
+      (task) =>
+        `${sparqlEscapeUri(task)} dct:isPartOf ${sparqlEscapeUri(job.job)}.`,
+    )
+    .join("\n");
 
   const updateQuery = `
     ${SPARQL_PREFIXES}
@@ -92,4 +103,80 @@ export async function updateJob( job ){
   await update(updateQuery);
 
   return loadJob(job.job);
+}
+
+// now that a job can have multiple tasks going in parallel, it's no longer
+// enough to check if a delta received completed task is the final one in the job
+// and the job has only completed tasks.
+export async function isJobComplete(job) {
+  return !(await hasNonFinalOrIncompleteTask(job));
+}
+
+async function hasNonFinalOrIncompleteTask(job) {
+  const finalOperations = getFinalOperations(job);
+  const safeFinalOperationValues = finalOperations
+    .map(sparqlEscapeUri)
+    .join("\n");
+  const safeFinalOperationFilter = finalOperations
+    .map(sparqlEscapeUri)
+    .join(", ");
+
+  // union part1: get me my tasks that are last in chain and not final,
+  // if they are not failed, we still need to continue the chain
+
+  // union part2: get me my tasks that are last in chain and final,
+  // if their status is not failed or success, we're not done with them yet
+  const result = await query(`
+    PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+    SELECT * WHERE {
+      ?task dct:isPartOf ${sparqlEscapeUri(job.job)} .
+      FILTER NOT EXISTS {
+        ?next <http://vocab.deri.ie/cogs#dependsOn> ?task .
+      }
+        
+      {
+        ?task task:operation ?op .
+        FILTER(?op NOT IN ( ${safeFinalOperationFilter} ) )
+        FILTER NOT EXISTS {
+          ?task adms:status ${sparqlEscapeUri(STATUS_FAILED)} .
+        }
+      } UNION {
+        VALUES ?finalOp {
+          ${safeFinalOperationValues}
+        }
+        ?task task:operation ?finalOp.
+        ?task adms:status ?status .
+        FILTER (?status NOT IN ( ${sparqlEscapeUri(STATUS_FAILED)}, ${sparqlEscapeUri(STATUS_SUCCESS)} ))
+      }
+
+    } limit 1
+  `);
+
+  return result.results.bindings.length > 0;
+}
+
+// there can in theory be multiple final operations if the config makes it a graph
+// simply mark the operations as final if there is no follow up defined
+// we are assuming here that the graph is acyclic, but that seems like a fair assumption atm
+function getFinalOperations(job) {
+  const config = jobsConfig[job.operation];
+  if (!config)
+    throw new Error(
+      `No config for operation "${job.operation}" could be found.`,
+    );
+  const taskConfig = config.tasksConfiguration;
+  if (!taskConfig)
+    throw new Error(
+      `The configuration for "${job.operation}" might be malformed.`,
+    );
+  const possiblyFinal = new Set();
+  taskConfig.forEach((task) => {
+    possiblyFinal.add(task.nextOperation);
+  });
+  taskConfig.forEach((task) => {
+    possiblyFinal.delete(task.currentOperation);
+  });
+  return [...possiblyFinal];
 }

--- a/lib/task.js
+++ b/lib/task.js
@@ -213,25 +213,3 @@ export async function updateTaskStatus(task, status) {
       }
     }`);
 }
-
-/**
- * Returns whether the job has only successful tasks (with status STATUS_SUCCESS)
- *
- * @public
- * @async
- * @function
- * @param {string} job - Represents the URI of the job
- * @returns {boolean} true if there are only successful tasks in the job, false otherwise
- */
-export async function hasOnlySuccessfulTasks(job){
-  const result = await query(`
-    ${SPARQL_PREFIXES}
-    SELECT * WHERE {
-      ?task dct:isPartOf ${sparqlEscapeUri(job)} ;
-                adms:status ?status .
-      FILTER (?status NOT IN ( ${sparqlEscapeUri(STATUS_SUCCESS)} ))
-
-    } LIMIT 1
-  `);
-  return result.results.bindings.length === 0;
-}


### PR DESCRIPTION
job completeness is now more complicated, now that the tasks can actually be a tree

we need to check all final tasks in the chain and see if they are indeed in the set of final operations AND if they are complete.

this can be tested without running the AI services by adding a 'hacky' service to the stack that picks up and completes heavy ai tasks:

config/hacky/app.js
```
import { app } from 'mu';
import { updateSudo as update } from '@lblod/mu-auth-sudo';

app.post('/delta', async function (req, res) {
  res.send('ok');
  completeOpenAnnotationJobs().catch((e) => console.log(e));
});

async function completeOpenAnnotationJobs() {
  await update(`
    PREFIX adms: <http://www.w3.org/ns/adms#>
    PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
    DELETE {
     graph ?g {
       ?s adms:status ?status .
     }
    } INSERT {
     graph ?g {
       ?s adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> .
     }
    } WHERE {
     graph ?g {
      VALUES ?ops {
       <http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-translation>
       <http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-entity-extracting>
       <http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-entity-linking>
       <http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate>
       <http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/train>
       <http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/assess-impact>
      }
      ?s task:operation ?ops ;
         adms:status ?status . 
      FILTER(?status != <http://redpencil.data.gift/id/concept/JobStatus/success>)
     }
    }
    `);
}

```

config/hacky/package.json
```
{
  "name": "hacky-service",
  "version": "1.3.0",
  "description": "Microservice responsible for managing a job and its related tasks.",
  "repository": {
    "type": "git",
    "url": "git+https://github.com/lblod/job-controller-service.git"
  },
  "author": "redpencil.io",
  "license": "MIT",
  "dependencies": {
    "@lblod/mu-auth-sudo": "^1.0.0-beta.4",
    "body-parser": "~1.20.1",
    "n3": "^2.0.3",
    "rdf-string-ttl": "^2.0.1"
  },
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "volta": {
    "node": "20.19.0"
  }
}

```

docker-compose.override.yml
```
hacky:
    image: semtech/mu-javascript-template:1.9.1
    environment:
      NODE_ENV: "development"
    volumes:
      - ./config/hacky:/app/
```

Be sure to build the latest version of this service and the task splitter here: https://github.com/lblod/annotation-job-splitter-service/pull/4

You can create a codelist evaluation task with any codelist and any three decisions to verify that this works, e.g. 
http://data.lblod.gift/id/conceptscheme/restricted-mobility-zone-simple

and
https://data.gent.be/id/besluiten/25.1210.5026.7790
https://data.gent.be/id/besluiten/26.0204.0946.0133
https://data.gent.be/id/besluiten/26.0205.7074.8416

in graph http://mu.semte.ch/graphs/public/gent