### PR TITLE
fix: job controller was stuck after receiving an error

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,20 @@ async function handleOpenTasks() {
   }
   lock = mylock;
 
+  await unsafeHandleOpenTasks().catch((e) => {
+    console.log(`Something went wrong while handling open tasks: ${e}`);
+  });
+
+  if (lock === mylock) {
+    lock = null;
+    return;
+  } else {
+    lock = null;
+    await handleOpenTasks();
+  }
+}
+
+async function unsafeHandleOpenTasks() {
   let currentBatch = await getBatchTasksToConsiderForScheduling();
   while (currentBatch.length > 0) {
     const todo = [...currentBatch];
@@ -49,14 +63,6 @@ async function handleOpenTasks() {
     }
 
     currentBatch = await getBatchTasksToConsiderForScheduling();
-  }
-
-  if (lock === mylock) {
-    lock = null;
-    return;
-  } else {
-    lock = null;
-    await handleOpenTasks();
   }
 }
 


### PR DESCRIPTION
## description
fix: job controller was stuck in error state if a query failed
imagine your db is not up yet, the query fails on startup, but this keeps the running variable set and noone will clear it.
This resolves that
## how to test 
- use this version of the job-controller in your decide compose setup
- kill the triplestore
- start the job-controller linker and watch it error but not kill itself
- restart the triplestore
- trigger a delta to the job controller, e.g. start a new job
- watch the job controller's logs and wait for it to complete
- check the status of the jobs, notice that the new tasks are created as configured