### PR TITLE
fix job controller removing jobs temporarily

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ import {
   getBatchTasksToConsiderForScheduling,
   markTaskScheduled,
 } from "./lib/task";
-import { isJobComplete, loadJob, updateJob } from "./lib/job";
+import { isJobComplete, loadJob, updateJobStatus } from "./lib/job";
 import * as jobsConfig from "./config/config.json";
 import { CronJob } from "cron";
 
@@ -135,8 +135,7 @@ async function scheduleNextTask(currentTaskUri) {
     const previousTaskConfig = getPreviousTaskConfig(jobsConfig, job, task);
     if (previousTaskConfig && (await isJobComplete(job))) {
       //Task operation found as next operation is this config, so this is final task in job
-      job.status = STATUS_SUCCESS;
-      await updateJob(job);
+      await updateJobStatus(job, STATUS_SUCCESS);
     } else if (!previousTaskConfig) {
       //Task operation is never referenced, then there is no config for this: do nothing other than fail/stop
       throw new Error(
@@ -171,8 +170,6 @@ async function scheduleNextTask(currentTaskUri) {
     );
 
     job.tasks.push(nextTask.task);
-
-    await updateJob(job);
   }
 }
 
@@ -193,8 +190,7 @@ async function handleFailedTask(currentTaskUri) {
     return;
   }
 
-  job.status = STATUS_FAILED;
-  await updateJob(job);
+  await updateJobStatus(job, STATUS_FAILED);
 }
 
 function getCurrentTaskConfig(jobsConfiguration, job, currentTask) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -49,60 +49,36 @@ export async function loadJob(subject) {
   return job;
 }
 
-export async function updateJob(job) {
-  //TODO: review the error flow
-  // Probably we want to attach the error to the task
-  // and it somehow 'bubbles up' to the job
+export async function updateJobStatus(job, statusUri) {
   job.modified = new Date();
-
-  const tasksTriples = job.tasks
-    .map(
-      (task) =>
-        `${sparqlEscapeUri(task)} dct:isPartOf ${sparqlEscapeUri(job.job)}.`,
-    )
-    .join("\n");
+  job.status = statusUri;
 
   const updateQuery = `
     ${SPARQL_PREFIXES}
     DELETE {
       GRAPH ?g {
-        ?job dct:creator ?creator;
-           adms:status ?status;
-           dct:created ?created;
-           task:operation ?operation;
+        ?job adms:status ?status;
            dct:modified ?modified.
+      }
+    }
+    INSERT {
+      GRAPH ${sparqlEscapeUri(job.graph)} {
+        ?job adms:status ${sparqlEscapeUri(job.status)} .
+        ?job dct:modified ${sparqlEscapeDateTime(job.modified)} .
       }
     }
     WHERE {
       GRAPH ?g {
-       BIND(${sparqlEscapeUri(job.job)} AS ?job)
-       ?job a ${sparqlEscapeUri(JOB_TYPE)};
-         dct:creator ?creator;
-         adms:status ?status;
-         dct:created ?created;
-         task:operation ?operation;
-         dct:modified ?modified.
+       VALUES ?job {
+        ${sparqlEscapeUri(job.job)}
+       }
+       ?job adms:status ?status .
+       OPTIONAL {
+         ?job dct:modified ?modified.
+       }       
       }
-    }
-
-    ;
-
-    INSERT DATA {
-      GRAPH ${sparqlEscapeUri(job.graph)}{
-        ${sparqlEscapeUri(job.job)} dct:creator ${sparqlEscapeUri(job.creator)};
-           adms:status ${sparqlEscapeUri(job.status)};
-           dct:created ${sparqlEscapeDateTime(job.created)};
-           task:operation ${sparqlEscapeUri(job.operation)};
-           dct:modified ${sparqlEscapeDateTime(job.modified)}.
-
-        ${tasksTriples}
-      }
-    }
-  `;
-
+    }`;
   await update(updateQuery);
-
-  return loadJob(job.job);
 }
 
 // now that a job can have multiple tasks going in parallel, it's no longer

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED, STATUS_SUCCESS, BATCH_SIZE } from '../constants';
+import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED, STATUS_SUCCESS, BATCH_SIZE, JOB_TYPE } from '../constants';
 import { parseResult, writeTriplesToGraph } from './utils';
 
 import * as N3 from 'n3';
@@ -143,7 +143,12 @@ export async function createTask( graph, job, index, operation, status, parentTa
 
    const insertQuery = `
     ${SPARQL_PREFIXES}
-    INSERT DATA {
+    DELETE {
+      GRAPH ?g {
+        ?job dct:modified ?modified.
+      }
+    }
+    INSERT {
       GRAPH ${sparqlEscapeUri(graph)} {
        ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(TASK_TYPE)};
                 mu:uuid ${sparqlEscapeString(id)};
@@ -155,6 +160,19 @@ export async function createTask( graph, job, index, operation, status, parentTa
                 task:operation ${sparqlEscapeUri(operation)}.
 
         ${parentTaskTriples}
+
+        ?job dct:modified ${sparqlEscapeDateTime(new Date())} .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        VALUES ?job {
+          ${sparqlEscapeUri(job)}
+        }
+        ?job a ${sparqlEscapeUri(JOB_TYPE)};
+        OPTIONAL {
+          ?job dct:modified ?modified.
+        }        
       }
     }
   `;

--- a/lib/task.js
+++ b/lib/task.js
@@ -169,7 +169,7 @@ export async function createTask( graph, job, index, operation, status, parentTa
         VALUES ?job {
           ${sparqlEscapeUri(job)}
         }
-        ?job a ${sparqlEscapeUri(JOB_TYPE)};
+        ?job a ${sparqlEscapeUri(JOB_TYPE)} .
         OPTIONAL {
           ?job dct:modified ?modified.
         }        

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED, STATUS_SUCCESS, BATCH_SIZE, JOB_TYPE } from '../constants';
+import { TASK_TYPE, SPARQL_PREFIXES, TASK_URI_PREFIX, STATUS_FAILED, STATUS_SCHEDULED, BATCH_SIZE, JOB_TYPE } from '../constants';
 import { parseResult, writeTriplesToGraph } from './utils';
 
 import * as N3 from 'n3';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-controller-service",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-controller-service",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^1.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-controller-service",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "Microservice responsible for managing a job and its related tasks.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Previously, the job controller removed all triples of a job and then reinserted them, it did this whenever it updated the status of a job, but it also did this in two parts: a delete query to remove, then an insert query to insert.

This results in a period where the job does not exist (between the delete and insert). This is especially noticeable when the job has many tasks and resulted in issues with scheduled jobs being started when there were in fact already too many jobs running.

This pr changes the logic so that the job controller no longer attempts to destroy data that it should leave unchanged. It now only updates status (when required) and links new tasks to the job. In both cases it updates the jobs modification date. All other properties of the job are left unchanged.

## How to test

Take the latest decide setup and apply the 'hacky' service to the decide stack to simulate AI jobs being run instantly, see https://github.com/lblod/job-controller-service/pull/9 
Create a codelist mapping (training) job for any codelist (doesn't have to exist)
use the gent graph and the following three expressions:
https://data.gent.be/id/besluiten/21.0611.0808.1525
https://data.gent.be/id/besluiten/21.0623.5420.9194
https://data.gent.be/id/besluiten/21.0624.1838.2842

The tasks and jobs should complete successfully